### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Pluralization can be used in combination with string formatting.
 
 | Key              | Value                          | Comment                                 |
 |------------------|--------------------------------|-----------------------------------------|
-| FileShared_One   | {0} shared {1} photos from {2} | #ReswPlusTyped[s(username), Q, s(city)] |
+| FileShared_One   | {0} shared {1} photo from {2}  | #ReswPlusTyped[s(username), Q, s(city)] |
 | FileShared_Other | {0} shared {1} photos from {2} |                                         |
 
 Will generate:


### PR DESCRIPTION
`FileShared_One` should be `{0} shared {1} photo from {2}` (singular) instead of `{0} shared {1} photos from {2}` (plural)