### PR TITLE
Allow the code generator to create more than 1 file

### DIFF
--- a/src/VSExtension/ReswPlusVSIX/Languages/CSharpCodeGenerator.cs
+++ b/src/VSExtension/ReswPlusVSIX/Languages/CSharpCodeGenerator.cs
@@ -46,9 +46,9 @@ namespace ReswPlus.Languages
             _builder.AppendEmptyLine();
         }
 
-        public string GetString()
+        public IEnumerable<GeneratedFile> GetGeneratedFiles()
         {
-            return _builder.GetString();
+            yield return new GeneratedFile() { Extension = ".cs", Content = _builder.GetString() };
         }
 
         public void GetHeaders(bool supportPluralization)

--- a/src/VSExtension/ReswPlusVSIX/Languages/CppCodeGenerator.cs
+++ b/src/VSExtension/ReswPlusVSIX/Languages/CppCodeGenerator.cs
@@ -46,9 +46,9 @@ namespace ReswPlus.Languages
             _builder.AppendEmptyLine();
         }
 
-        public string GetString()
+        public IEnumerable<GeneratedFile> GetGeneratedFiles()
         {
-            return _builder.GetString();
+            yield return new GeneratedFile() { Extension = ".h", Content = _builder.GetString() };
         }
 
         public void GetHeaders(bool supportPluralization)

--- a/src/VSExtension/ReswPlusVSIX/Languages/ICodeGenerator.cs
+++ b/src/VSExtension/ReswPlusVSIX/Languages/ICodeGenerator.cs
@@ -3,6 +3,11 @@ using System.Collections.Generic;
 
 namespace ReswPlus.Languages
 {
+    internal class GeneratedFile
+    {
+        public string Extension { get; set; }
+        public string Content { get; set; }
+    }
     internal interface ICodeGenerator
     {
         string GetParameterTypeString(ParameterType type);
@@ -25,6 +30,6 @@ namespace ReswPlus.Languages
             FunctionParameter extraParameterForFunction = null, FunctionParameter parameterForPluralization = null);
 
         void CreateMarkupExtension(string resourceFileName, string className, IEnumerable<string> keys);
-        string GetString();
+        IEnumerable<GeneratedFile> GetGeneratedFiles();
     }
 }

--- a/src/VSExtension/ReswPlusVSIX/Languages/VBCodeGenerator.cs
+++ b/src/VSExtension/ReswPlusVSIX/Languages/VBCodeGenerator.cs
@@ -54,9 +54,9 @@ namespace ReswPlus.Languages
             _builder.AppendEmptyLine();
         }
 
-        public string GetString()
+        public IEnumerable<GeneratedFile> GetGeneratedFiles()
         {
-            return _builder.GetString();
+            yield return new GeneratedFile() { Extension = ".vb", Content = _builder.GetString() };
         }
 
         public void GetHeaders(bool supportPluralization)

--- a/src/VSExtension/ReswPlusVSIX/ReswPlusVSIX.csproj
+++ b/src/VSExtension/ReswPlusVSIX/ReswPlusVSIX.csproj
@@ -73,6 +73,7 @@
     <Compile Include="Resw\ReswItem.cs" />
     <Compile Include="SingleFileGenerators\ReswPlusGenerator.cs" />
     <Compile Include="ReswPlusPackage.cs" />
+    <Compile Include="Utils\NugetHelper.cs" />
     <Compile Include="Utils\ProjectItemExtension.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/VSExtension/ReswPlusVSIX/Utils/NugetHelper.cs
+++ b/src/VSExtension/ReswPlusVSIX/Utils/NugetHelper.cs
@@ -1,0 +1,37 @@
+using EnvDTE;
+using Microsoft.VisualStudio.ComponentModelHost;
+using Microsoft.VisualStudio.Shell;
+using NuGet.VisualStudio;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ReswPlus.Utils
+{
+    public static class NugetHelper
+    {
+        public static bool InstallNuGetPackage(this Project project, string package)
+        {
+            try
+            {
+                var componentModel = (IComponentModel)Package.GetGlobalService(typeof(SComponentModel));
+                var installerServices = componentModel.GetService<IVsPackageInstallerServices>();
+                if (!installerServices.IsPackageInstalled(project, package))
+                {
+                    var installer = componentModel.GetService<IVsPackageInstaller>();
+                    installer.InstallPackage(null, project, package, (System.Version)null, false);
+                    return true;
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Can't install {package} nuget package: {ex.Message}");
+            }
+            return false;
+        }
+
+    }
+}


### PR DESCRIPTION
Change necessary to support cpp/winrt (3 files to generate: .idl, .h and .cpp) and to modify how we generate the cpp/cx strongly typed class (currently 1 single header file, soon .h + .cpp)