### PR TITLE
use Namespace alias and namespace declarations in generated cpp files

### DIFF
--- a/src/VSExtension/Tests/CppCXTest/TestCppCX/Strings/en/Resources.generated.cpp
+++ b/src/VSExtension/Tests/CppCXTest/TestCppCX/Strings/en/Resources.generated.cpp
@@ -3,43 +3,47 @@
 #include <pch.h>
 #include "Resources.generated.h"
 #include <stdio.h>
+using namespace Platform;
+using namespace Windows::ApplicationModel::Resources;
+using namespace Windows::UI::Xaml::Interop;
+namespace local = TestCppCX::Strings;
 
-Windows::ApplicationModel::Resources::ResourceLoader^ TestCppCX::Strings::Resources::_resourceLoader = nullptr;
-Windows::ApplicationModel::Resources::ResourceLoader^ TestCppCX::Strings::Resources::GetResourceLoader()
+ResourceLoader^ local::Resources::_resourceLoader = nullptr;
+ResourceLoader^ local::Resources::GetResourceLoader()
 {
     if (_resourceLoader == nullptr)
     {
-        _resourceLoader = Windows::ApplicationModel::Resources::ResourceLoader::GetForViewIndependentUse(L"Resources");
+        _resourceLoader = ResourceLoader::GetForViewIndependentUse(L"Resources");
     }
     return _resourceLoader;
 }
 
-Platform::String^ TestCppCX::Strings::Resources::YouGotEmails(double number)
+String^ local::Resources::YouGotEmails(double number)
 {
     return ReswPlusLib::ResourceLoaderExtension::GetPlural(GetResourceLoader(), L"YouGotEmails", number);
 }
 
-Platform::String^ TestCppCX::Strings::Resources::YouGotEmails_Format(unsigned int numberMessages, Platform::String^ username)
+String^ local::Resources::YouGotEmails_Format(unsigned int numberMessages, String^ username)
 {
     size_t needed = _swprintf_p(nullptr, 0, YouGotEmails(static_cast<double>(numberMessages))->Data(), numberMessages, username->Data());
     wchar_t *buffer = new wchar_t[needed + 1];
     _swprintf_p(buffer, needed + 1, YouGotEmails(static_cast<double>(numberMessages))->Data(), numberMessages, username->Data());
-    return ref new Platform::String(buffer);
+    return ref new String(buffer);
 }
 
-Platform::String^ TestCppCX::Strings::Resources::Hello::get()
+String^ local::Resources::Hello::get()
 {
     return GetResourceLoader()->GetString(L"Hello");
 }
 
-TestCppCX::Strings::ResourcesExtension::ResourcesExtension()
+local::ResourcesExtension::ResourcesExtension()
 {
-    _resourceLoader = Windows::ApplicationModel::Resources::ResourceLoader::GetForViewIndependentUse(L"Resources");
+    _resourceLoader = ResourceLoader::GetForViewIndependentUse(L"Resources");
 }
 
-Platform::Object^ TestCppCX::Strings::ResourcesExtension::ProvideValue()
+Object^ local::ResourcesExtension::ProvideValue()
 {
-    Platform::String^ res;
+    String^ res;
     if(Key == KeyEnum::__Undefined)
     {
         res = L"";
@@ -48,5 +52,5 @@ Platform::Object^ TestCppCX::Strings::ResourcesExtension::ProvideValue()
     {
         res = _resourceLoader->GetString(Key.ToString());
     }
-    return Converter == nullptr ? res : Converter->Convert(res, Windows::UI::Xaml::Interop::TypeName(Platform::String::typeid), ConverterParameter, nullptr);
+    return Converter == nullptr ? res : Converter->Convert(res, TypeName(String::typeid), ConverterParameter, nullptr);
 }


### PR DESCRIPTION
Create a namespace alias (locale::) for the current namespace.
Use namespace declarations in generated cpp files to make the code more readable.